### PR TITLE
Add Vibe skills for reusable actions

### DIFF
--- a/.vibe/skills/dogfood-reusable-action/SKILL.md
+++ b/.vibe/skills/dogfood-reusable-action/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: dogfood-reusable-action
+description: Use this when adding or changing a reusable workflow, composite action, or CI helper. Ensures the repository includes a practical example that exercises the same public interface consumers will use.
+---
+
+# Dogfood Reusable Actions
+
+Every reusable action or workflow change must include a dogfood path that proves the public use case works.
+
+When creating or updating a reusable workflow or composite action:
+
+1. Identify the consumer-facing interface:
+   - `workflow_call` inputs, secrets, outputs, and permissions for reusable workflows.
+   - `inputs`, `outputs`, and runtime assumptions for composite actions.
+2. Add or update a repository workflow under `.github/workflows/` that calls the reusable workflow or action through that public interface.
+3. Keep the dogfood workflow small and realistic:
+   - Use a minimal fixture project or temporary files created during the job.
+   - Exercise required inputs and at least one representative optional input.
+   - Validate expected outputs or side effects with explicit shell assertions.
+4. Prefer local dogfooding for in-repository development:
+   - Reusable workflow: `uses: ./.github/workflows/<workflow>.yml`
+   - Composite action: `uses: ./path/to/action`
+5. If GitHub requires remote invocation for the scenario, call the repository action/workflow from the task branch and document why local invocation is not enough.
+
+Before finishing:
+
+- Run the closest local validation available for the dogfood path.
+- If the behavior only runs on GitHub, ensure the workflow can be triggered with `workflow_dispatch` or by pull request.
+- Report exactly which dogfood workflow exercises the changed reusable action or workflow.

--- a/.vibe/skills/github-action-pinning/SKILL.md
+++ b/.vibe/skills/github-action-pinning/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: github-action-pinning
+description: Use this when creating or updating GitHub Actions workflows, reusable workflows, or composite actions. Ensures third-party actions use the latest release and are pinned by immutable commit SHA.
+---
+
+# GitHub Action Pinning
+
+When editing any workflow or action that uses another GitHub Action:
+
+1. Inventory every `uses:` entry you touch.
+2. Classify each entry:
+   - Local actions (`./...`) do not need SHA pinning.
+   - Docker actions (`docker://...`) must use immutable digests when possible.
+   - Repository actions (`owner/repo[/path]@ref`) must use commit SHA pins.
+3. For each repository action, resolve the latest appropriate upstream version:
+   - Prefer the latest stable GitHub release.
+   - If no releases exist, use the latest semver tag.
+   - If no tags exist, use the repository default branch HEAD.
+4. Pin the action to the commit SHA for that version.
+5. Preserve the human-readable version in a comment next to the pin.
+
+Preferred format:
+
+```yaml
+- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+```
+
+For actions with subpaths, pin the repository ref only:
+
+```yaml
+- uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+```
+
+Before finishing:
+
+- Verify no touched third-party action still points to a mutable ref such as `main`, `master`, or `v1`.
+- Verify each pinned SHA is 40 lowercase hexadecimal characters.
+- Verify the comment matches the release or tag that resolved to the SHA.
+- Mention any action that could not be resolved or pinned, and why.

--- a/.vibe/skills/quality-gate/SKILL.md
+++ b/.vibe/skills/quality-gate/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: quality-gate
+description: Use this for every code, workflow, action, documentation, or configuration change. Requires discovering and running the relevant tests, linters, formatters, and validation commands before delivery.
+---
+
+# Quality Gate
+
+Before delivering changes:
+
+1. Discover quality commands from repository files instead of guessing:
+   - `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, and docs.
+   - Package manifests such as `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, `justfile`, or workflow files.
+2. Run the narrowest relevant check first.
+3. Run broader checks when the change can affect shared behavior, CI, or reusable actions.
+4. For GitHub Actions content, include static validation when available:
+   - `actionlint` for workflow syntax and common mistakes.
+   - YAML formatting/linting when configured.
+5. If no project-specific command exists, perform available baseline checks:
+   - Parse changed YAML files.
+   - Inspect shell snippets with `bash -n` when extractable.
+   - Review changed files for unresolved placeholders, TODO-only behavior, and secret-like values.
+
+When a check fails:
+
+- Determine whether the failure is caused by the current change.
+- Fix in-scope failures before delivery.
+- For unrelated or environment-blocked failures, report the exact command and the key error.
+
+Delivery must include:
+
+- The commands run.
+- Whether each command passed, failed, or was skipped with a reason.

--- a/.vibe/skills/reusable-action-contract/SKILL.md
+++ b/.vibe/skills/reusable-action-contract/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: reusable-action-contract
+description: Use this when designing reusable GitHub Actions workflows or composite actions. Ensures public interfaces are stable, documented, minimal, and safe for many repositories.
+---
+
+# Reusable Action Contract
+
+Reusable workflows and composite actions are public APIs. Treat changes to them as contract changes.
+
+When adding or changing one:
+
+1. Keep the interface minimal and explicit:
+   - Declare all inputs with clear descriptions.
+   - Mark required inputs only when a safe default is impossible.
+   - Declare outputs that consumers can rely on.
+   - Document required secrets and permissions.
+2. Prefer secure defaults:
+   - Set the least required `permissions` for workflows and jobs.
+   - Avoid exposing secrets to pull requests from forks.
+   - Avoid command injection by quoting shell variables and validating user-controlled inputs.
+3. Keep behavior portable across Sheplu repositories:
+   - Avoid repository-specific paths unless configurable.
+   - Use language/tool auto-detection only when deterministic.
+   - Fail fast with actionable errors when prerequisites are missing.
+4. Document the contract in `README.md` or action-local documentation:
+   - Purpose and expected use cases.
+   - Minimal example.
+   - Inputs, outputs, secrets, permissions, and assumptions.
+   - Versioning and migration notes for breaking changes.
+5. Preserve backward compatibility unless the user explicitly asks for a breaking change.
+
+Before finishing:
+
+- Compare the docs, dogfood workflow, and implementation to ensure they describe the same interface.
+- Call out any breaking change explicitly.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Cikit
+
 Reusable CI/CD workflows for consistent automation across all Cikit-powered projects.
+
+## Vibe project skills
+
+This repository includes project-local Vibe skills in `.vibe/skills/` to keep reusable GitHub Actions work consistent:
+
+- `github-action-pinning`: resolve touched third-party actions to their latest stable version and pin them by commit SHA.
+- `dogfood-reusable-action`: require a small dogfood workflow or equivalent path that exercises the public action/workflow interface.
+- `quality-gate`: discover and run relevant tests, linters, formatters, and static validation before delivery.
+- `reusable-action-contract`: treat reusable workflows and composite actions as stable public contracts with documented inputs, outputs, secrets, permissions, and safe defaults.
+
+Vibe discovers these skills automatically when run from this trusted repository. Load the relevant skill before adding or changing reusable workflows, composite actions, or CI helpers.


### PR DESCRIPTION
## Summary
- Add four project-local Vibe skills for reusable GitHub Actions work
- Cover SHA-pinned latest actions, dogfooding, quality gates, and reusable action contracts
- Document the skills in the repository README

## Verification
- `python - <<'PY' ...` parsed every `.vibe/skills/*/SKILL.md` frontmatter with Vibe's skill parser and validated skill names match directories
- `python - <<'PY' ...` reviewed README and skill files for tabs and placeholder markers
- `python - <<'PY' ...` verified README lists every skill directory
