### PR TITLE
chore(skills): add PR and commit conventions

### DIFF
--- a/.vibe/skills/pr-commit-conventions/SKILL.md
+++ b/.vibe/skills/pr-commit-conventions/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: pr-commit-conventions
+description: Use this before creating commits, pushing branches, or opening pull requests. Enforces repository-owner commit attribution, conventional commit messages, and clean PR metadata.
+---
+
+# PR and Commit Conventions
+
+Use this skill before committing changes, pushing a branch, or opening a pull request.
+
+## Commit attribution
+
+1. Resolve the repository owner from the `origin` remote (`owner/repo`).
+2. Create commits using the repository owner's Git identity when it is available for the repository.
+3. Do not set an AI tool, bot, assistant, model, or vendor as the commit `Author`, `Committer`, or `Co-authored-by` trailer.
+4. Do not add AI attribution trailers or generated-by footers, including variants such as:
+   - `Co-authored-by: Claude ...`
+   - `Co-authored-by: ChatGPT ...`
+   - `Co-authored-by: OpenAI ...`
+   - `Co-authored-by: Mistral ...`
+   - `Generated with ...`
+5. Before pushing, inspect the commit metadata and message to confirm the author, committer, and trailers comply.
+
+## Commit messages
+
+Use Conventional Commits:
+
+```text
+<type>(optional-scope): <short imperative summary>
+```
+
+Allowed common types include:
+
+- `feat`: user-visible feature or capability
+- `fix`: bug fix
+- `chore`: maintenance that is not user-visible
+- `docs`: documentation-only change
+- `refactor`: code restructuring without behavior change
+- `test`: tests only
+- `ci`: CI workflow or automation change
+- `build`: build system, packaging, or dependency metadata change
+- `perf`: performance improvement
+- `style`: formatting-only change
+- `revert`: revert a prior change
+
+Scopes are optional and may be used when they clarify the affected module, for example:
+
+```text
+feat(actions): add reusable release workflow
+fix(lint): handle missing config
+chore: update repository skills
+```
+
+Keep the subject concise, imperative, and lowercase after the type unless a proper noun is required.
+
+## Pull requests
+
+1. Use a branch name that identifies the task and is safe to push to the remote.
+2. Keep the PR focused on the commits in the branch.
+3. Write the PR title using the same Conventional Commit style as the primary commit when possible.
+4. In the PR body, summarize the change and list verification commands run.
+5. Do not add AI attribution, AI co-authoring notes, or generated-by statements to the PR title, body, labels, or comments.
+
+## Pre-push checklist
+
+- `git status` contains only intended changes.
+- `git log -1 --format=fuller` shows a repository-owner human identity, not an AI identity.
+- `git log -1 --format=%B` uses an allowed Conventional Commit type and has no AI attribution trailers.
+- The PR title/body do not mention AI authorship or co-authorship.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository includes project-local Vibe skills in `.vibe/skills/` to keep re
 - `github-action-pinning`: resolve touched third-party actions to their latest stable version and pin them by commit SHA.
 - `dogfood-reusable-action`: require a small dogfood workflow or equivalent path that exercises the public action/workflow interface.
 - `quality-gate`: discover and run relevant tests, linters, formatters, and static validation before delivery.
+- `pr-commit-conventions`: enforce repository-owner commit attribution, Conventional Commit messages, and PR metadata without AI authorship or co-authorship mentions.
 - `reusable-action-contract`: treat reusable workflows and composite actions as stable public contracts with documented inputs, outputs, secrets, permissions, and safe defaults.
 
 Vibe discovers these skills automatically when run from this trusted repository. Load the relevant skill before adding or changing reusable workflows, composite actions, or CI helpers.


### PR DESCRIPTION
## Summary
- Add a `pr-commit-conventions` Vibe skill for commits, branches, and PRs.
- Enforce repository-owner commit attribution, Conventional Commit messages, and no AI authorship/co-authorship metadata.
- Document the new skill in the README skill list.

## Verification
- `git diff --check`
- `python3 - <<'PY' ... PY` markdown baseline checks
- `grep -RInE '(api[_-]?key|secret|token|password|-----BEGIN)' README.md .vibe/skills/pr-commit-conventions/SKILL.md || true`
- `git log -1 --format=fuller`
- `git log -1 --format=%B`
