### PR TITLE
feat(workflows): add reusable Node.js automation

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,0 +1,262 @@
+name: Reusable dependency guard
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version used to run @sheplu/dependency-guard.
+        required: false
+        type: string
+        default: 24.x
+      working-directory:
+        description: Directory containing the package.json to inspect.
+        required: false
+        type: string
+        default: .
+      package-json:
+        description: Path to package.json relative to working-directory.
+        required: false
+        type: string
+        default: package.json
+      dependency-guard-version:
+        description: Version or dist-tag of @sheplu/dependency-guard to run.
+        required: false
+        type: string
+        default: latest
+      registry-url:
+        description: Registry URL passed to dependency-guard.
+        required: false
+        type: string
+        default: https://registry.npmjs.org
+      fail-on:
+        description: Optional dependency-guard --fail-on value.
+        required: false
+        type: string
+        default: ''
+      max-age:
+        description: Optional dependency-guard --max-age value in days.
+        required: false
+        type: string
+        default: ''
+      prod:
+        description: Check production dependencies.
+        required: false
+        type: boolean
+        default: true
+      dev:
+        description: Check dev dependencies.
+        required: false
+        type: boolean
+        default: true
+      peer:
+        description: Check peer dependencies.
+        required: false
+        type: boolean
+        default: true
+      optional:
+        description: Check optional dependencies.
+        required: false
+        type: boolean
+        default: true
+      ignore-scopes:
+        description: Comma- or newline-separated scopes to ignore, such as @internal.
+        required: false
+        type: string
+        default: ''
+      only:
+        description: Comma- or newline-separated package names to check.
+        required: false
+        type: string
+        default: ''
+      no-cache:
+        description: Disable dependency-guard registry cache.
+        required: false
+        type: boolean
+        default: false
+      checkout-ref:
+        description: Optional Git ref to checkout. Defaults to the workflow event ref.
+        required: false
+        type: string
+        default: ''
+    outputs:
+      total:
+        description: Total dependencies reported by dependency-guard.
+        value: ${{ jobs.dependency_guard.outputs.total }}
+      up-to-date:
+        description: Dependencies reported as up to date.
+        value: ${{ jobs.dependency_guard.outputs.up_to_date }}
+      minor-updates:
+        description: Dependencies with minor updates.
+        value: ${{ jobs.dependency_guard.outputs.minor_updates }}
+      major-updates:
+        description: Dependencies with major updates.
+        value: ${{ jobs.dependency_guard.outputs.major_updates }}
+
+permissions:
+  contents: read
+
+jobs:
+  dependency_guard:
+    name: Dependency guard
+    runs-on: ubuntu-latest
+    outputs:
+      total: ${{ steps.summary.outputs.total }}
+      up_to_date: ${{ steps.summary.outputs.up_to_date }}
+      minor_updates: ${{ steps.summary.outputs.minor_updates }}
+      major_updates: ${{ steps.summary.outputs.major_updates }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Run dependency guard
+        id: guard
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_JSON: ${{ inputs.package-json }}
+          DEPENDENCY_GUARD_VERSION: ${{ inputs.dependency-guard-version }}
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          FAIL_ON: ${{ inputs.fail-on }}
+          MAX_AGE: ${{ inputs.max-age }}
+          CHECK_PROD: ${{ inputs.prod }}
+          CHECK_DEV: ${{ inputs.dev }}
+          CHECK_PEER: ${{ inputs.peer }}
+          CHECK_OPTIONAL: ${{ inputs.optional }}
+          IGNORE_SCOPES: ${{ inputs.ignore-scopes }}
+          ONLY_PACKAGES: ${{ inputs.only }}
+          NO_CACHE: ${{ inputs.no-cache }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "${PACKAGE_JSON}" ]; then
+            echo "::error::Package manifest '${PACKAGE_JSON}' not found in ${PWD}."
+            exit 1
+          fi
+
+          case "${DEPENDENCY_GUARD_VERSION}" in
+            ''|*[!A-Za-z0-9._@+-]*)
+              echo "::error::Invalid dependency-guard version '${DEPENDENCY_GUARD_VERSION}'."
+              exit 1
+              ;;
+          esac
+
+          args=(--path "${PACKAGE_JSON}" --format json --registry "${REGISTRY_URL}")
+
+          [ "${CHECK_PROD}" = "true" ] && args+=(--prod)
+          [ "${CHECK_DEV}" = "true" ] && args+=(--dev)
+          [ "${CHECK_PEER}" = "true" ] && args+=(--peer)
+          [ "${CHECK_OPTIONAL}" = "true" ] && args+=(--optional)
+
+          if [ -n "${FAIL_ON}" ]; then
+            case "${FAIL_ON}" in
+              *[!A-Za-z0-9._-]*)
+                echo "::error::Invalid fail-on value '${FAIL_ON}'."
+                exit 1
+                ;;
+            esac
+            args+=(--fail-on "${FAIL_ON}")
+          fi
+
+          if [ -n "${MAX_AGE}" ]; then
+            case "${MAX_AGE}" in
+              *[!0-9]*)
+                echo "::error::max-age must be a number of days."
+                exit 1
+                ;;
+            esac
+            args+=(--max-age "${MAX_AGE}")
+          fi
+
+          if [ "${NO_CACHE}" = "true" ]; then
+            args+=(--no-cache)
+          fi
+
+          add_list_args() {
+            local flag="$1"
+            local values="$2"
+            local item
+            while IFS= read -r item; do
+              item="${item#"${item%%[![:space:]]*}"}"
+              item="${item%"${item##*[![:space:]]}"}"
+              [ -z "${item}" ] && continue
+              case "${item}" in
+                *[!A-Za-z0-9@._/-]*)
+                  echo "::error::Invalid value '${item}' for ${flag}."
+                  exit 1
+                  ;;
+              esac
+              args+=("${flag}" "${item}")
+            done < <(printf '%s\n' "${values}" | tr ',' '\n')
+          }
+
+          add_list_args --ignore-scope "${IGNORE_SCOPES}"
+          add_list_args --only "${ONLY_PACKAGES}"
+
+          set +e
+          npx --yes "@sheplu/dependency-guard@${DEPENDENCY_GUARD_VERSION}" "${args[@]}" > "${RUNNER_TEMP}/dependency-guard.json"
+          exit_code="$?"
+          set -e
+
+          {
+            echo "json_path=${RUNNER_TEMP}/dependency-guard.json"
+            echo "exit_code=${exit_code}"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ "${exit_code}" -ne 0 ]; then
+            if ! node -e "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))" "${RUNNER_TEMP}/dependency-guard.json"; then
+              exit "${exit_code}"
+            fi
+          fi
+
+      - name: Write dependency guard summary
+        id: summary
+        env:
+          DEPENDENCY_GUARD_JSON: ${{ steps.guard.outputs.json_path }}
+          DEPENDENCY_GUARD_EXIT_CODE: ${{ steps.guard.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const data = JSON.parse(fs.readFileSync(process.env.DEPENDENCY_GUARD_JSON, 'utf8'));
+          const summary = data.summary || {};
+          const dependencies = Array.isArray(data.dependencies) ? data.dependencies : [];
+          const rows = dependencies.map((dependency) => {
+            const updateType = dependency.updateType || 'unknown';
+            const current = dependency.current?.version || '-';
+            const latestMinor = dependency.latestMinor?.version || '-';
+            const latestMajor = dependency.latestMajor?.version || '-';
+            const age = typeof dependency.ageInDays === 'number' ? `${dependency.ageInDays}d` : '-';
+            return `| ${dependency.name || '-'} | ${dependency.type || '-'} | ${current} | ${latestMinor} | ${latestMajor} | ${age} | ${updateType} |`;
+          });
+
+          const markdown = [
+            '## Dependency guard',
+            '',
+            `- Total: ${summary.total ?? dependencies.length}`,
+            `- Up to date: ${summary.upToDate ?? 0}`,
+            `- Minor updates: ${summary.minorUpdates ?? 0}`,
+            `- Major updates: ${summary.majorUpdates ?? 0}`,
+            '',
+            '| Package | Type | Current | Latest minor | Latest major | Age | Status |',
+            '| --- | --- | --- | --- | --- | --- | --- |',
+            ...(rows.length > 0 ? rows : ['| _No dependencies reported_ | - | - | - | - | - | - |']),
+            '',
+          ].join('\n');
+
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, [
+            `total=${summary.total ?? dependencies.length}`,
+            `up_to_date=${summary.upToDate ?? 0}`,
+            `minor_updates=${summary.minorUpdates ?? 0}`,
+            `major_updates=${summary.majorUpdates ?? 0}`,
+            '',
+          ].join('\n'));
+          NODE
+          exit "${DEPENDENCY_GUARD_EXIT_CODE}"

--- a/.github/workflows/dogfood-node.yml
+++ b/.github/workflows/dogfood-node.yml
@@ -1,0 +1,52 @@
+name: Dogfood Node.js reusable workflows
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/node-ci.yml
+      - .github/workflows/npm-publish.yml
+      - .github/workflows/dependency-guard.yml
+      - .github/workflows/dogfood-node.yml
+      - fixtures/node-basic/**
+      - README.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  node-ci:
+    name: Node.js CI fixture
+    uses: ./.github/workflows/node-ci.yml
+    with:
+      node-version: 24.x
+      working-directory: fixtures/node-basic
+      package-manager: npm
+      scripts: lint,typecheck,test,build
+      skip-missing-scripts: false
+
+  dependency-guard:
+    name: Dependency guard fixture
+    uses: ./.github/workflows/dependency-guard.yml
+    with:
+      node-version: 24.x
+      working-directory: fixtures/node-basic
+      package-json: package.json
+      prod: true
+      dev: true
+      peer: true
+      optional: true
+
+  npm-publish-dry-run:
+    name: npm publish dry-run fixture
+    uses: ./.github/workflows/npm-publish.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      node-version: 24.x
+      working-directory: fixtures/node-basic
+      package-manager: npm
+      quality-scripts: lint,typecheck,test,build
+      skip-missing-scripts: false
+      dry-run: true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,260 @@
+name: Reusable Node.js CI
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version passed to actions/setup-node.
+        required: false
+        type: string
+        default: 24.x
+      working-directory:
+        description: Directory containing package.json.
+        required: false
+        type: string
+        default: .
+      package-manager:
+        description: Package manager to use. Set to auto, npm, pnpm, or yarn.
+        required: false
+        type: string
+        default: auto
+      install:
+        description: Install dependencies before running scripts.
+        required: false
+        type: boolean
+        default: true
+      cache:
+        description: Enable setup-node dependency caching when a lockfile is present.
+        required: false
+        type: boolean
+        default: true
+      scripts:
+        description: Comma- or newline-separated package scripts to run in order.
+        required: false
+        type: string
+        default: lint,typecheck,test,build
+      skip-missing-scripts:
+        description: Skip requested scripts that are not defined in package.json.
+        required: false
+        type: boolean
+        default: true
+      checkout-ref:
+        description: Optional Git ref to checkout. Defaults to the workflow event ref.
+        required: false
+        type: string
+        default: ''
+    outputs:
+      package-manager:
+        description: Detected or selected package manager.
+        value: ${{ jobs.node_ci.outputs.package_manager }}
+      scripts-run:
+        description: Comma-separated list of package scripts that ran.
+        value: ${{ jobs.node_ci.outputs.scripts_run }}
+
+permissions:
+  contents: read
+
+jobs:
+  node_ci:
+    name: Node.js CI
+    runs-on: ubuntu-latest
+    outputs:
+      package_manager: ${{ steps.detect.outputs.package_manager }}
+      scripts_run: ${{ steps.run-scripts.outputs.ran }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Detect package manager
+        id: detect
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          REQUESTED_PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          CACHE_ENABLED: ${{ inputs.cache }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f package.json ]; then
+            echo "::error::package.json not found in ${PWD}."
+            exit 1
+          fi
+
+          requested="${REQUESTED_PACKAGE_MANAGER}"
+          package_manager_field="$(node <<'NODE'
+          const fs = require('node:fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const packageManager = typeof pkg.packageManager === 'string'
+          ? pkg.packageManager
+          : '';
+          console.log(packageManager.includes('@')
+          ? packageManager.slice(0, packageManager.lastIndexOf('@'))
+          : packageManager);
+          NODE
+          )"
+
+          case "${requested}" in
+            auto|'')
+              if [ -n "${package_manager_field}" ]; then
+                manager="${package_manager_field}"
+              elif [ -f pnpm-lock.yaml ]; then
+                manager="pnpm"
+              elif [ -f yarn.lock ]; then
+                manager="yarn"
+              else
+                manager="npm"
+              fi
+              ;;
+            npm|pnpm|yarn)
+              manager="${requested}"
+              ;;
+            *)
+              echo "::error::Unsupported package manager '${requested}'. Use auto, npm, pnpm, or yarn."
+              exit 1
+              ;;
+          esac
+
+          case "${manager}" in
+            npm)
+              lockfile=""
+              [ -f package-lock.json ] && lockfile="package-lock.json"
+              [ -f npm-shrinkwrap.json ] && lockfile="npm-shrinkwrap.json"
+              ;;
+            pnpm)
+              lockfile=""
+              [ -f pnpm-lock.yaml ] && lockfile="pnpm-lock.yaml"
+              ;;
+            yarn)
+              lockfile=""
+              [ -f yarn.lock ] && lockfile="yarn.lock"
+              ;;
+            *)
+              echo "::error::Unsupported package manager '${manager}' from package.json packageManager field."
+              exit 1
+              ;;
+          esac
+
+          cache_manager=""
+          if [ "${CACHE_ENABLED}" = "true" ] && [ -n "${lockfile}" ]; then
+            cache_manager="${manager}"
+          fi
+
+          {
+            echo "package_manager=${manager}"
+            echo "lockfile=${lockfile}"
+            echo "cache_manager=${cache_manager}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Node.js with dependency cache
+        if: steps.detect.outputs.cache_manager != ''
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ steps.detect.outputs.cache_manager }}
+          cache-dependency-path: ${{ inputs.working-directory }}/${{ steps.detect.outputs.lockfile }}
+
+      - name: Setup Node.js
+        if: steps.detect.outputs.cache_manager == ''
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        if: inputs.install
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ steps.detect.outputs.package_manager }}
+        run: |
+          set -euo pipefail
+          if [ "${PACKAGE_MANAGER}" = "pnpm" ] || [ "${PACKAGE_MANAGER}" = "yarn" ]; then
+            if ! command -v "${PACKAGE_MANAGER}" >/dev/null 2>&1; then
+              corepack enable
+            fi
+          fi
+
+          case "${PACKAGE_MANAGER}" in
+            npm)
+              if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+                npm ci
+              else
+                npm install
+              fi
+              ;;
+            pnpm)
+              if [ -f pnpm-lock.yaml ]; then
+                pnpm install --frozen-lockfile
+              else
+                pnpm install
+              fi
+              ;;
+            yarn)
+              if yarn --version | grep -q '^1\.'; then
+                if [ -f yarn.lock ]; then
+                  yarn install --frozen-lockfile
+                else
+                  yarn install
+                fi
+              elif [ -f yarn.lock ]; then
+                yarn install --immutable
+              else
+                yarn install
+              fi
+              ;;
+          esac
+
+      - name: Run requested package scripts
+        id: run-scripts
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ steps.detect.outputs.package_manager }}
+          REQUESTED_SCRIPTS: ${{ inputs.scripts }}
+          SKIP_MISSING_SCRIPTS: ${{ inputs.skip-missing-scripts }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { spawnSync } = require('node:child_process');
+
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const requested = (process.env.REQUESTED_SCRIPTS || '')
+            .split(/[\n,]/)
+            .map((script) => script.trim())
+            .filter(Boolean);
+          const skipMissing = process.env.SKIP_MISSING_SCRIPTS === 'true';
+          const packageManager = process.env.PACKAGE_MANAGER || 'npm';
+          const definedScripts = pkg.scripts || {};
+          const missing = [];
+          const ran = [];
+
+          for (const script of requested) {
+            if (!Object.hasOwn(definedScripts, script)) {
+              missing.push(script);
+              continue;
+            }
+
+            const command = packageManager;
+            const args = packageManager === 'npm' ? ['run', script] : ['run', script];
+            console.log(`::group::${packageManager} run ${script}`);
+            const result = spawnSync(command, args, { stdio: 'inherit', shell: false });
+            console.log('::endgroup::');
+
+            if (result.status !== 0) {
+              process.exit(result.status || 1);
+            }
+            ran.push(script);
+          }
+
+          if (missing.length > 0) {
+            const message = `Missing package scripts: ${missing.join(', ')}`;
+            if (skipMissing) {
+              console.log(`::notice::${message}`);
+            } else {
+              console.error(`::error::${message}`);
+              process.exit(1);
+            }
+          }
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `ran=${ran.join(',')}\n`);
+          NODE

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,310 @@
+name: Reusable npm publish
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version passed to actions/setup-node.
+        required: false
+        type: string
+        default: 24.x
+      working-directory:
+        description: Directory containing the package.json to publish.
+        required: false
+        type: string
+        default: .
+      package-manager:
+        description: Package manager to use for install and quality scripts. Set to auto, npm, pnpm, or yarn.
+        required: false
+        type: string
+        default: auto
+      install:
+        description: Install dependencies before quality scripts and publish.
+        required: false
+        type: boolean
+        default: true
+      quality-scripts:
+        description: Comma- or newline-separated scripts to run before publishing.
+        required: false
+        type: string
+        default: lint,typecheck,test,build
+      skip-missing-scripts:
+        description: Skip quality scripts that are not defined in package.json.
+        required: false
+        type: boolean
+        default: true
+      registry-url:
+        description: npm-compatible registry URL.
+        required: false
+        type: string
+        default: https://registry.npmjs.org
+      tag:
+        description: npm dist-tag to publish.
+        required: false
+        type: string
+        default: latest
+      access:
+        description: npm package access. Use public for public scoped packages, restricted for private scopes, or empty to omit.
+        required: false
+        type: string
+        default: public
+      provenance:
+        description: Add npm provenance attestation for real publishes.
+        required: false
+        type: boolean
+        default: true
+      dry-run:
+        description: Run npm publish --dry-run instead of publishing.
+        required: false
+        type: boolean
+        default: false
+      checkout-ref:
+        description: Optional Git ref to checkout. Defaults to the workflow event ref.
+        required: false
+        type: string
+        default: ''
+    secrets:
+      npm-token:
+        description: Optional npm automation token. Prefer npm trusted publishing with id-token permissions when available.
+        required: false
+    outputs:
+      package-name:
+        description: Name read from package.json.
+        value: ${{ jobs.publish.outputs.package_name }}
+      package-version:
+        description: Version read from package.json.
+        value: ${{ jobs.publish.outputs.package_version }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.package.outputs.name }}
+      package_version: ${{ steps.package.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Detect package manager
+        id: detect
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          REQUESTED_PACKAGE_MANAGER: ${{ inputs.package-manager }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f package.json ]; then
+            echo "::error::package.json not found in ${PWD}."
+            exit 1
+          fi
+
+          requested="${REQUESTED_PACKAGE_MANAGER}"
+          package_manager_field="$(node <<'NODE'
+          const fs = require('node:fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const packageManager = typeof pkg.packageManager === 'string'
+          ? pkg.packageManager
+          : '';
+          console.log(packageManager.includes('@')
+          ? packageManager.slice(0, packageManager.lastIndexOf('@'))
+          : packageManager);
+          NODE
+          )"
+
+          case "${requested}" in
+            auto|'')
+              if [ -n "${package_manager_field}" ]; then
+                manager="${package_manager_field}"
+              elif [ -f pnpm-lock.yaml ]; then
+                manager="pnpm"
+              elif [ -f yarn.lock ]; then
+                manager="yarn"
+              else
+                manager="npm"
+              fi
+              ;;
+            npm|pnpm|yarn)
+              manager="${requested}"
+              ;;
+            *)
+              echo "::error::Unsupported package manager '${requested}'. Use auto, npm, pnpm, or yarn."
+              exit 1
+              ;;
+          esac
+
+          case "${manager}" in
+            npm|pnpm|yarn) ;;
+            *)
+              echo "::error::Unsupported package manager '${manager}' from package.json packageManager field."
+              exit 1
+              ;;
+          esac
+
+          echo "package_manager=${manager}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: ${{ inputs.registry-url }}
+
+      - name: Install dependencies
+        if: inputs.install
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ steps.detect.outputs.package_manager }}
+        run: |
+          set -euo pipefail
+          if [ "${PACKAGE_MANAGER}" = "pnpm" ] || [ "${PACKAGE_MANAGER}" = "yarn" ]; then
+            if ! command -v "${PACKAGE_MANAGER}" >/dev/null 2>&1; then
+              corepack enable
+            fi
+          fi
+
+          case "${PACKAGE_MANAGER}" in
+            npm)
+              if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+                npm ci
+              else
+                npm install
+              fi
+              ;;
+            pnpm)
+              if [ -f pnpm-lock.yaml ]; then
+                pnpm install --frozen-lockfile
+              else
+                pnpm install
+              fi
+              ;;
+            yarn)
+              if yarn --version | grep -q '^1\.'; then
+                if [ -f yarn.lock ]; then
+                  yarn install --frozen-lockfile
+                else
+                  yarn install
+                fi
+              elif [ -f yarn.lock ]; then
+                yarn install --immutable
+              else
+                yarn install
+              fi
+              ;;
+          esac
+
+      - name: Run quality scripts
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ steps.detect.outputs.package_manager }}
+          REQUESTED_SCRIPTS: ${{ inputs.quality-scripts }}
+          SKIP_MISSING_SCRIPTS: ${{ inputs.skip-missing-scripts }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { spawnSync } = require('node:child_process');
+
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const requested = (process.env.REQUESTED_SCRIPTS || '')
+            .split(/[\n,]/)
+            .map((script) => script.trim())
+            .filter(Boolean);
+          const skipMissing = process.env.SKIP_MISSING_SCRIPTS === 'true';
+          const packageManager = process.env.PACKAGE_MANAGER || 'npm';
+          const definedScripts = pkg.scripts || {};
+          const missing = [];
+
+          for (const script of requested) {
+            if (!Object.hasOwn(definedScripts, script)) {
+              missing.push(script);
+              continue;
+            }
+
+            console.log(`::group::${packageManager} run ${script}`);
+            const result = spawnSync(packageManager, ['run', script], { stdio: 'inherit', shell: false });
+            console.log('::endgroup::');
+
+            if (result.status !== 0) {
+              process.exit(result.status || 1);
+            }
+          }
+
+          if (missing.length > 0) {
+            const message = `Missing package scripts: ${missing.join(', ')}`;
+            if (skipMissing) {
+              console.log(`::notice::${message}`);
+            } else {
+              console.error(`::error::${message}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
+      - name: Read package metadata
+        id: package
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          if (!pkg.name || !pkg.version) {
+            console.error('::error::package.json must define name and version before publish.');
+            process.exit(1);
+          }
+          if (pkg.private === true && process.env.DRY_RUN !== 'true') {
+            console.error('::error::Refusing to publish a package with private: true.');
+            process.exit(1);
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${pkg.name}\nversion=${pkg.version}\n`);
+          NODE
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
+
+      - name: Publish package
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets['npm-token'] }}
+          NPM_CONFIG_REGISTRY: ${{ inputs.registry-url }}
+          NPM_TAG: ${{ inputs.tag }}
+          NPM_ACCESS: ${{ inputs.access }}
+          NPM_PROVENANCE: ${{ inputs.provenance }}
+          NPM_DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+
+          case "${NPM_TAG}" in
+            ''|*[!A-Za-z0-9._-]*)
+              echo "::error::Invalid npm dist-tag '${NPM_TAG}'."
+              exit 1
+              ;;
+          esac
+
+          args=(publish --tag "${NPM_TAG}")
+
+          if [ -n "${NPM_ACCESS}" ]; then
+            case "${NPM_ACCESS}" in
+              public|restricted) args+=(--access "${NPM_ACCESS}") ;;
+              *)
+                echo "::error::Invalid npm access '${NPM_ACCESS}'. Use public, restricted, or empty."
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [ "${NPM_PROVENANCE}" = "true" ] && [ "${NPM_DRY_RUN}" != "true" ]; then
+            args+=(--provenance)
+          fi
+
+          if [ "${NPM_DRY_RUN}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+
+          npm "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,153 @@
 
 Reusable CI/CD workflows for consistent automation across all Cikit-powered projects.
 
+## Node.js reusable workflows
+
+These workflows are designed for Node.js packages like `@sheplu/dependency-guard` and other npm-style projects.
+They are reusable workflow contracts, so consumers should call them from their own repository workflows with `uses:`.
+
+### Node.js CI
+
+Runs dependency installation plus package scripts such as `lint`, `typecheck`, `test`, and `build`.
+It auto-detects npm, pnpm, or Yarn from `packageManager` and lockfiles, or the package manager can be set explicitly.
+
+```yaml
+jobs:
+  ci:
+    uses: sheplu/Cikit/.github/workflows/node-ci.yml@main
+    with:
+      node-version: 24.x
+      scripts: lint,typecheck,test,build
+      skip-missing-scripts: false
+```
+
+Inputs:
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `node-version` | `24.x` | Node.js version passed to `actions/setup-node`. |
+| `working-directory` | `.` | Directory containing `package.json`. |
+| `package-manager` | `auto` | `auto`, `npm`, `pnpm`, or `yarn`. |
+| `install` | `true` | Install dependencies before scripts. |
+| `cache` | `true` | Enable dependency caching when a lockfile is present. |
+| `scripts` | `lint,typecheck,test,build` | Comma- or newline-separated scripts to run in order. |
+| `skip-missing-scripts` | `true` | Skip missing package scripts instead of failing. |
+| `checkout-ref` | empty | Optional Git ref to checkout. |
+
+Outputs:
+
+| Output | Description |
+| --- | --- |
+| `package-manager` | Detected or selected package manager. |
+| `scripts-run` | Comma-separated list of scripts that ran. |
+
+Required permissions: `contents: read`.
+
+### Dependency guard
+
+Runs `@sheplu/dependency-guard` and writes a dependency summary to the GitHub job summary.
+It exposes the package summary counts as outputs for downstream gates or notifications.
+
+```yaml
+jobs:
+  dependency-guard:
+    uses: sheplu/Cikit/.github/workflows/dependency-guard.yml@main
+    with:
+      node-version: 24.x
+      fail-on: major
+      ignore-scopes: '@internal'
+```
+
+Inputs:
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `node-version` | `24.x` | Node.js version used to run `@sheplu/dependency-guard`. |
+| `working-directory` | `.` | Directory containing the package manifest. |
+| `package-json` | `package.json` | Package manifest path relative to `working-directory`. |
+| `dependency-guard-version` | `latest` | Version or dist-tag of `@sheplu/dependency-guard`. |
+| `registry-url` | `https://registry.npmjs.org` | Registry URL passed to dependency-guard. |
+| `fail-on` | empty | Optional dependency-guard `--fail-on` value. |
+| `max-age` | empty | Optional dependency-guard `--max-age` value in days. |
+| `prod` | `true` | Include production dependencies. |
+| `dev` | `true` | Include development dependencies. |
+| `peer` | `true` | Include peer dependencies. |
+| `optional` | `true` | Include optional dependencies. |
+| `ignore-scopes` | empty | Comma- or newline-separated scopes to ignore. |
+| `only` | empty | Comma- or newline-separated package names to check. |
+| `no-cache` | `false` | Disable dependency-guard registry cache. |
+| `checkout-ref` | empty | Optional Git ref to checkout. |
+
+Outputs:
+
+| Output | Description |
+| --- | --- |
+| `total` | Total dependencies reported. |
+| `up-to-date` | Dependencies reported as up to date. |
+| `minor-updates` | Dependencies with minor updates. |
+| `major-updates` | Dependencies with major updates. |
+
+Required permissions: `contents: read`.
+
+### npm publish
+
+Runs optional quality scripts and publishes a package to npm. It supports npm trusted publishing through OIDC
+or an optional `npm-token` secret. Use `dry-run: true` for release validation without publishing.
+
+```yaml
+jobs:
+  publish:
+    uses: sheplu/Cikit/.github/workflows/npm-publish.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      node-version: 24.x
+      quality-scripts: lint,typecheck,test,build
+      dry-run: ${{ github.event_name != 'release' }}
+```
+
+Inputs:
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `node-version` | `24.x` | Node.js version passed to `actions/setup-node`. |
+| `working-directory` | `.` | Directory containing the package to publish. |
+| `package-manager` | `auto` | `auto`, `npm`, `pnpm`, or `yarn`. |
+| `install` | `true` | Install dependencies before quality scripts and publish. |
+| `quality-scripts` | `lint,typecheck,test,build` | Comma- or newline-separated scripts to run before publishing. |
+| `skip-missing-scripts` | `true` | Skip missing quality scripts instead of failing. |
+| `registry-url` | `https://registry.npmjs.org` | npm-compatible registry URL. |
+| `tag` | `latest` | npm dist-tag. |
+| `access` | `public` | `public`, `restricted`, or empty to omit `--access`. |
+| `provenance` | `true` | Add npm provenance attestation for real publishes. |
+| `dry-run` | `false` | Run `npm publish --dry-run` instead of publishing. |
+| `checkout-ref` | empty | Optional Git ref to checkout. |
+
+Secrets:
+
+| Secret | Required | Description |
+| --- | --- | --- |
+| `npm-token` | No | Optional npm automation token. Prefer trusted publishing with `id-token: write`. |
+
+Outputs:
+
+| Output | Description |
+| --- | --- |
+| `package-name` | Name read from package.json. |
+| `package-version` | Version read from package.json. |
+
+Required permissions: `contents: read`; add `id-token: write` for trusted publishing and npm provenance.
+
+## Dogfood workflow
+
+`.github/workflows/dogfood-node.yml` exercises all three public reusable workflow interfaces against
+`fixtures/node-basic`:
+
+- `node-ci.yml` runs the fixture `lint`, `typecheck`, `test`, and `build` scripts.
+- `dependency-guard.yml` runs `@sheplu/dependency-guard` on the fixture manifest.
+- `npm-publish.yml` runs the same quality scripts and `npm publish --dry-run`.
+
 ## Vibe project skills
 
 This repository includes project-local Vibe skills in `.vibe/skills/` to keep reusable GitHub Actions work consistent:

--- a/fixtures/node-basic/package-lock.json
+++ b/fixtures/node-basic/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "@sheplu/cikit-node-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sheplu/cikit-node-fixture",
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    }
+  }
+}

--- a/fixtures/node-basic/package.json
+++ b/fixtures/node-basic/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sheplu/cikit-node-fixture",
+  "version": "0.0.0",
+  "description": "Fixture used to dogfood Cikit reusable Node.js workflows.",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "lint": "node scripts/lint.js",
+    "typecheck": "node scripts/typecheck.js",
+    "test": "node --test 'test/**/*.test.js'",
+    "build": "node scripts/build.js",
+    "prepublishOnly": "node scripts/build.js"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/fixtures/node-basic/scripts/build.js
+++ b/fixtures/node-basic/scripts/build.js
@@ -1,0 +1,4 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+mkdirSync(new URL('../dist', import.meta.url), { recursive: true });
+writeFileSync(new URL('../dist/index.js', import.meta.url), 'export const ok = true;\n');

--- a/fixtures/node-basic/scripts/lint.js
+++ b/fixtures/node-basic/scripts/lint.js
@@ -1,0 +1,7 @@
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+if (pkg.type !== 'module') {
+  throw new Error('fixture package must stay ESM');
+}

--- a/fixtures/node-basic/scripts/typecheck.js
+++ b/fixtures/node-basic/scripts/typecheck.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+
+/** @type {{ name: string, version: string }} */
+const pkg = (await import('../package.json', { with: { type: 'json' } })).default;
+
+assert.equal(pkg.name, '@sheplu/cikit-node-fixture');
+assert.match(pkg.version, /^\d+\.\d+\.\d+$/);

--- a/fixtures/node-basic/test/basic.test.js
+++ b/fixtures/node-basic/test/basic.test.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('fixture can run on the active Node.js runtime', () => {
+  const major = Number.parseInt(process.versions.node.split('.')[0], 10);
+  assert.ok(major >= 20);
+});


### PR DESCRIPTION
## Summary
- Add reusable Node.js CI, dependency guard, and npm publish workflows for npm-style projects.
- Document workflow contracts, inputs, outputs, secrets, and permissions in the README.
- Add a dogfood workflow and minimal Node.js fixture to exercise the public reusable workflow interfaces.

## Verification
- `python3 - <<'PY' ... PY` — parsed all workflow YAML and ran `bash -n` on each workflow shell step.
- `cd fixtures/node-basic && node --run lint && node --run typecheck && node --run test && node --run build`
- `cd fixtures/node-basic && node /tmp/dependency-guard-0.3.0/package/dist/index.js --path package.json --format json --no-cache`
- `python3 - <<'PY' ... PY` — rendered the dependency guard summary step from fixture JSON.

## Notes
- Local `npm ci` / `npm publish --dry-run` could not be used in the sandbox because the available npm process crashes with a Node.js out-of-memory error before operating on the fixture.
- `actionlint` was not available locally, so workflow validation used PyYAML plus `bash -n` for embedded shell.
